### PR TITLE
fix(ci): remove unused System.Formats.Asn1 from central package management

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -32,6 +32,5 @@
     <PackageVersion Include="Snapshooter.Xunit" Version="0.14.1" />
     <PackageVersion Include="Spectre.Console" Version="0.50.0" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
-    <PackageVersion Include="System.Formats.Asn1" Version="9.0.4" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## What broke

The `continuous` CI workflow was failing with:
```
error NU1510: Warning As Error: PackageReference System.Formats.Asn1 will not be pruned.
Consider removing this package from your dependencies, as it is likely unnecessary.
```

This caused the Restore target to fail, blocking all subsequent steps (Compile, UnitTests, Pack).

## Root cause

`System.Formats.Asn1` was listed in `src/Directory.Packages.props` (central package management) but is not explicitly referenced by any project in the solution. In .NET 10, the SDK generates `NU1510` warnings for such orphaned entries. Since the CI uses `TreatWarningsAsErrors`, this was promoted to a build-breaking error.

## What was fixed

Removed the unused `System.Formats.Asn1` entry from `src/Directory.Packages.props`.

This package is a transitive dependency pulled in by other packages — it doesn't need to be explicitly listed in central package management.

## Verification

- `dotnet restore` should succeed without NU1510
- All downstream targets (Compile, UnitTests, Pack) unblocked