### PR TITLE
fix(ci): remove orphaned System.Formats.Asn1 ref from dependencies.props

### DIFF
--- a/src/build/dotnet/dependencies.props
+++ b/src/build/dotnet/dependencies.props
@@ -44,7 +44,6 @@
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit.Analyzers" PrivateAssets="all"/>
     <PackageReference Include="NUnit3TestAdapter" />
-    <PackageReference Include="System.Formats.Asn1" />
     <PackageReference Include="coverlet.collector" PrivateAssets="all" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## What broke
The `continuous` CI workflow has been failing since commit `92b7e17` with:

```
error NU1010: The following PackageReference items do not define a corresponding
PackageVersion item: System.Formats.Asn1 [Mutty.sln]
```

## Why it broke

Commit `92b7e17` (authored by Garry) correctly removed `System.Formats.Asn1` from `src/Directory.Packages.props` — it was an unused entry generating NU1510 warnings.

However, it missed the **companion reference** in `src/build/dotnet/dependencies.props` (test-project item group), which still declares:
```xml
<PackageReference Include="System.Formats.Asn1" />
```

With CPM active (`ManagePackageVersionsCentrally=true`), every `<PackageReference>` must have a matching `<PackageVersion>` entry. Since the version entry was removed but the reference remained, NuGet raises NU1010 and the restore fails.

## What was fixed

Removed the `System.Formats.Asn1` `PackageReference` from the test-specific `ItemGroup` in `dependencies.props`. This completes the cleanup started in `92b7e17`.

`System.Formats.Asn1` is **not directly used** in any test source file — it is a transitive dependency resolved automatically by the Roslyn testing packages. No explicit reference is needed.

## How to test

CI `continuous` workflow should pass — specifically the `Restore` target that was failing.

---
*Auto-fix PR by Ritchie (automated CI health check — 2026-02-18)*