### PR TITLE
feat(build): activate NuGet package validator in CI pipeline

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -168,7 +168,7 @@ class Build : NukeBuild
         .Requires(() => Configuration.Equals(Configuration.Release))
         .Produces(ArtifactsDirectory / ArtifactsType)
         .DependsOn(Compile, UnitTests)
-        .Triggers(PublishToGithub, PublishToNuGet)
+        .Triggers(PublishToGithub, PublishToNuGet, ValidateNuGetPackage)
         .Executes(() =>
         {
             Log.Information("Packing NuGet package");
@@ -286,30 +286,27 @@ class Build : NukeBuild
         await GitHubTasks.GitHubClient.Repository.Release.UploadAsset(release, assetUpload);
     }
     
-    // Target InstallNuGetValidator => _ => _
-    //     .DependsOn(Pack)
-    //     .Executes(() =>
-    //     {
-    //         // Ensure the tool is installed globally
-    //         ProcessTasks.StartProcess("dotnet", "tool update Meziantou.Framework.NuGetPackageValidation.Tool --global");
-    //     });
-    //
-    // Target ValidateNuGetPackage => _ => _
-    //     .DependsOn(InstallNuGetValidator)
-    //     .Executes(() =>
-    //     {
-    //         // Assuming NuGet packages are placed in "./.artifacts" directory
-    //         var nuGetPackages = (RootDirectory / ".artifacts").GlobFiles("*.nupkg");
-    //         foreach (var package in nuGetPackages)
-    //         {
-    //             // Run validation for each package
-    //             IProcess processExitCode = ProcessTasks.StartProcess("dotnet", $"meziantou.validate-nuget-package {package}");
-    //             
-    //             // Check if the process was successful
-    //             if (processExitCode.ExitCode != 0)
-    //             {
-    //                 throw new Exception("NuGet package validation failed.");
-    //             }
-    //         }
-    //     });
+    Target InstallNuGetValidator => _ => _
+        .Description("Restore local dotnet tools (includes meziantou.validate-nuget-package)")
+        .DependsOn(Pack)
+        .Executes(() =>
+        {
+            // Restore local dotnet tools declared in .config/dotnet-tools.json
+            ProcessTasks.StartProcess("dotnet", "tool restore").AssertZeroExitCode();
+        });
+
+    Target ValidateNuGetPackage => _ => _
+        .Description("Validate packed NuGet packages with Meziantou's validator")
+        .DependsOn(InstallNuGetValidator)
+        .Executes(() =>
+        {
+            // Validate each .nupkg in the artifacts directory
+            var nuGetPackages = (RootDirectory / ".artifacts").GlobFiles("*.nupkg");
+            foreach (var package in nuGetPackages)
+            {
+                Log.Information("Validating NuGet package: {Package}", package);
+                IProcess process = ProcessTasks.StartProcess("dotnet", $"tool run meziantou.validate-nuget-package {package}");
+                process.AssertZeroExitCode();
+            }
+        });
 }


### PR DESCRIPTION
## What

Uncomments and activates the `meziantou.validate-nuget-package` targets that were already defined in `Build.cs` but commented out.

## Why

The validator tool (`meziantou.framework.nugetpackagevalidation.tool`) was already declared in `.config/dotnet-tools.json` (v1.0.43), so the infrastructure was ready — just needed to be wired in.

## Changes

- **`InstallNuGetValidator`**: restored using `dotnet tool restore` (local tool, not global install)
- **`ValidateNuGetPackage`**: runs `dotnet tool run meziantou.validate-nuget-package` on each `.nupkg` in `/.artifacts`
- **`Pack`**: now `.Triggers(ValidateNuGetPackage)` so validation runs automatically after packing

## How to test

Run `./build.sh --target Pack --configuration Release` — validation will run after packing completes.
