### PR TITLE
fix(build): upgrade OctoVersion.Tool 1.0.9 → 1.0.21 for net10.0 runtime

### DIFF
--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageDownload Include="Octopus.OctoVersion.Tool" Version="[1.0.9]" />
+    <PackageDownload Include="Octopus.OctoVersion.Tool" Version="[1.0.21]" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## What broke

The `continuous` CI workflow started failing on 2026-02-19 with:

```
You must install or update .NET to run this application.
App: ~/.nuget/packages/octopus.octoversion.tool/1.0.9/tools/net9.0/any/OctoVersion.Tool.dll
```

**Failed run:** https://github.com/phmatray/Mutty/actions/runs/22181342269

## Why it broke

`OctoVersion.Tool` 1.0.9 ships a `net9.0` binary. The GitHub Actions ubuntu-latest runner uses .NET SDK 10.0.103 (pinned in `global.json`) and does **not** include the .NET 9 runtime. The framework-dependent tool DLL therefore cannot execute.

## What was fixed

Updated `build/_build.csproj` to use `OctoVersion.Tool` **1.0.21**, which ships a `net10.0` binary — matching the project's `TargetFramework` and the CI runner's installed runtime.

| Field | Before | After |
|---|---|---|
| Package | Octopus.OctoVersion.Tool | Octopus.OctoVersion.Tool |
| Version | 1.0.9 | 1.0.21 |
| Tool TFM | net9.0 | net10.0 |

## How to test

Merge this PR and verify the `continuous` workflow passes on the next push to `main`.