### PR TITLE
fix(codegen): Don't add Mutable prefix to built-in types in generic collections

### DIFF
--- a/src/library/Mutty/Templates/MutableWrapperTemplate.cs
+++ b/src/library/Mutty/Templates/MutableWrapperTemplate.cs
@@ -174,11 +174,14 @@ public class MutableWrapperTemplate(RecordTokens tokens) : IndentedCodeBuilder
     private void GenerateCollectionProperty(PropertyModel property)
     {
         string mutableType = ConvertImmutableToMutable(property.Type);
-        string mutableItemType = GetMutableItemType(property.Type);
+        string itemType = GetMutableItemType(property.Type);
         string propertyType = property.PropertyType.ToString();
 
+        // Only add "Mutable" prefix to custom record types, not to primitive/built-in types
+        string finalItemType = IsBuiltInType(itemType) ? itemType : $"Mutable{itemType}";
+
         Summary($"Gets or sets the {propertyType} {property.Name}.");
-        Line($"public {mutableType}<Mutable{mutableItemType}> {property.Name} {{ get; set; }}");
+        Line($"public {mutableType}<{finalItemType}> {property.Name} {{ get; set; }}");
     }
 
     private string ConvertImmutableToMutable(string immutableType)
@@ -219,6 +222,23 @@ public class MutableWrapperTemplate(RecordTokens tokens) : IndentedCodeBuilder
         }
 
         return immutableType;
+    }
+
+    private bool IsBuiltInType(string typeName)
+    {
+        // C# built-in types and common .NET types that should not get "Mutable" prefix
+        string[] builtInTypes =
+        [
+            "string", "int", "long", "short", "byte", "sbyte",
+            "uint", "ulong", "ushort", "decimal", "double", "float",
+            "bool", "char", "object",
+            "DateTime", "DateTimeOffset", "TimeSpan", "Guid",
+            "Int16", "Int32", "Int64", "UInt16", "UInt32", "UInt64",
+            "Single", "Double", "Decimal", "Boolean", "String", "Char", "Object",
+            "Byte", "SByte"
+        ];
+
+        return builtInTypes.Contains(typeName);
     }
 
     private void GenerateImplicitOperatorToMutable()

--- a/src/library/Mutty/Templates/MutableWrapperTemplate.cs
+++ b/src/library/Mutty/Templates/MutableWrapperTemplate.cs
@@ -178,7 +178,7 @@ public class MutableWrapperTemplate(RecordTokens tokens) : IndentedCodeBuilder
         string propertyType = property.PropertyType.ToString();
 
         // Only add "Mutable" prefix to custom record types, not to primitive/built-in types
-        string finalItemType = IsBuiltInType(itemType) ? itemType : $"Mutable{itemType}";
+        string finalItemType = (IsBuiltInType(itemType)) ? itemType : $"Mutable{itemType}";
 
         Summary($"Gets or sets the {propertyType} {property.Name}.");
         Line($"public {mutableType}<{finalItemType}> {property.Name} {{ get; set; }}");


### PR DESCRIPTION
## What Changed
Fixed the code generator to correctly handle built-in types inside generic immutable collections.

## Problem
When generating mutable wrappers for records with properties like `ImmutableList<string>`, the generator was incorrectly adding a 'Mutable' prefix to built-in types, resulting in undefined types like `Mutablestring`.

Example:
```csharp
public record MyRecord
{
    public ImmutableList<string> Collect { get; init; }
}
```

Generated (before):
```csharp
public class MutableMyRecord
{
    public List<Mutablestring> Collect { get; set; }  // ❌ Mutablestring is undefined
}
```

Generated (after):
```csharp
public class MutableMyRecord
{
    public List<string> Collect { get; set; }  // ✅ Correct
}
```

## How Fixed
- Added `IsBuiltInType()` helper method to check if a type is a C# primitive or common .NET built-in type
- Modified `GenerateCollectionProperty()` to only add 'Mutable' prefix to custom record types, not built-in types
- Handles: string, int, long, DateTime, Guid, and other common types

## Testing
- Existing tests should pass
- Manually verified fix resolves the reported issue

Closes #65