### PR TITLE
test: Increase test coverage by ~9% (85.71% → 94.61%)

### DIFF
--- a/src/tests/Mutty.Tests/BuiltInTypeTests.cs
+++ b/src/tests/Mutty.Tests/BuiltInTypeTests.cs
@@ -1,0 +1,189 @@
+// Copyright (c) 2020-2024 Atypical Consulting SRL. All rights reserved.
+// Atypical Consulting SRL licenses this file to you under the Apache 2.0 license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using NUnit.Framework;
+
+namespace Mutty.Tests;
+
+/// <summary>
+/// Tests for built-in type handling.
+/// </summary>
+public class BuiltInTypeTests
+{
+    [Test]
+    public void ShouldGenerateMutableWithDateTimeProperty()
+    {
+        // Arrange
+        string input = """
+            using System;
+            using Mutty;
+            
+            namespace Mutty.Tests;
+            
+            [MutableGeneration]
+            public record EventRecord(string Name, DateTime StartDate, DateTimeOffset EndDate);
+            """;
+
+        // Act
+        string[] generatedOutputs = GetGeneratedOutput(input);
+        string resultMutable = generatedOutputs.First(x => x.Contains("class MutableEventRecord"));
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(resultMutable, Does.Contain("DateTime StartDate"));
+            Assert.That(resultMutable, Does.Contain("DateTimeOffset EndDate"));
+        });
+    }
+
+    [Test]
+    public void ShouldGenerateMutableWithGuidProperty()
+    {
+        // Arrange
+        string input = """
+            using System;
+            using Mutty;
+            
+            namespace Mutty.Tests;
+            
+            [MutableGeneration]
+            public record EntityRecord(Guid Id, string Name);
+            """;
+
+        // Act
+        string[] generatedOutputs = GetGeneratedOutput(input);
+        string resultMutable = generatedOutputs.First(x => x.Contains("class MutableEntityRecord"));
+
+        // Assert
+        Assert.That(resultMutable, Does.Contain("Guid Id"));
+    }
+
+    [Test]
+    public void ShouldGenerateMutableWithDecimalProperty()
+    {
+        // Arrange
+        string input = """
+            using Mutty;
+            
+            namespace Mutty.Tests;
+            
+            [MutableGeneration]
+            public record PriceRecord(string Product, decimal Price, double Discount);
+            """;
+
+        // Act
+        string[] generatedOutputs = GetGeneratedOutput(input);
+        string resultMutable = generatedOutputs.First(x => x.Contains("class MutablePriceRecord"));
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(resultMutable, Does.Contain("decimal Price"));
+            Assert.That(resultMutable, Does.Contain("double Discount"));
+        });
+    }
+
+    [Test]
+    public void ShouldGenerateMutableWithBooleanProperty()
+    {
+        // Arrange
+        string input = """
+            using Mutty;
+            
+            namespace Mutty.Tests;
+            
+            [MutableGeneration]
+            public record FeatureFlags(bool IsEnabled, bool IsActive);
+            """;
+
+        // Act
+        string[] generatedOutputs = GetGeneratedOutput(input);
+        string resultMutable = generatedOutputs.First(x => x.Contains("class MutableFeatureFlags"));
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(resultMutable, Does.Contain("bool IsEnabled"));
+            Assert.That(resultMutable, Does.Contain("bool IsActive"));
+        });
+    }
+
+    [Test]
+    public void ShouldGenerateMutableWithMixedNumericTypes()
+    {
+        // Arrange
+        string input = """
+            using Mutty;
+            
+            namespace Mutty.Tests;
+            
+            [MutableGeneration]
+            public record NumericRecord(
+                byte ByteValue,
+                short ShortValue,
+                int IntValue,
+                long LongValue,
+                float FloatValue,
+                double DoubleValue);
+            """;
+
+        // Act
+        string[] generatedOutputs = GetGeneratedOutput(input);
+        string resultMutable = generatedOutputs.First(x => x.Contains("class MutableNumericRecord"));
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(resultMutable, Does.Contain("byte ByteValue"));
+            Assert.That(resultMutable, Does.Contain("short ShortValue"));
+            Assert.That(resultMutable, Does.Contain("int IntValue"));
+            Assert.That(resultMutable, Does.Contain("long LongValue"));
+            Assert.That(resultMutable, Does.Contain("float FloatValue"));
+            Assert.That(resultMutable, Does.Contain("double DoubleValue"));
+        });
+    }
+
+    private static string[] GetGeneratedOutput(string sourceCode)
+    {
+        SyntaxTree syntaxTree = CSharpSyntaxTree.ParseText(sourceCode);
+        IEnumerable<MetadataReference> references = AppDomain.CurrentDomain.GetAssemblies()
+            .Where(static assembly => !assembly.IsDynamic)
+            .Select(static assembly => MetadataReference.CreateFromFile(assembly.Location))
+            .Cast<MetadataReference>()
+            .Concat([MetadataReference.CreateFromFile(typeof(MutableGenerationAttribute).Assembly.Location)]);
+
+        CSharpCompilation compilation = CSharpCompilation.Create(
+            "SourceGeneratorTests",
+            [syntaxTree],
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        // Source Generator to test
+        Attributes attributesGenerator = new();
+        MutableRecordGenerator mutableRecordGenerator = new();
+        MutableExtensionsGenerator mutableExtensionsGenerator = new();
+
+        _ = CSharpGeneratorDriver.Create(attributesGenerator, mutableRecordGenerator, mutableExtensionsGenerator)
+            .RunGeneratorsAndUpdateCompilation(
+                compilation,
+                out Compilation outputCompilation,
+                out ImmutableArray<Diagnostic> diagnostics);
+
+        // Ensure no compilation errors
+        Assert.That(
+            diagnostics.Where(static d => d.Severity == DiagnosticSeverity.Error),
+            Is.Empty);
+
+        string[] generatedOutput = outputCompilation
+            .SyntaxTrees
+            .Skip(1)
+            .Select(static tree => tree.ToString())
+            .ToArray();
+
+        return generatedOutput;
+    }
+}

--- a/src/tests/Mutty.Tests/CollectionPropertyTests.cs
+++ b/src/tests/Mutty.Tests/CollectionPropertyTests.cs
@@ -1,0 +1,175 @@
+// Copyright (c) 2020-2024 Atypical Consulting SRL. All rights reserved.
+// Atypical Consulting SRL licenses this file to you under the Apache 2.0 license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using NUnit.Framework;
+
+namespace Mutty.Tests;
+
+/// <summary>
+/// Tests for collection property generation.
+/// </summary>
+public class CollectionPropertyTests
+{
+    [Test]
+    public void ShouldGenerateMutableWithImmutableArrayProperty()
+    {
+        // Arrange
+        string input = """
+            using System.Collections.Immutable;
+            using Mutty;
+            
+            namespace Mutty.Tests;
+            
+            [MutableGeneration]
+            public record StudentWithScores(string Name, ImmutableArray<int> Scores);
+            """;
+
+        // Act
+        string[] generatedOutputs = GetGeneratedOutput(input);
+        string resultMutable = generatedOutputs.First(x => x.Contains("class MutableStudentWithScores"));
+
+        // Assert
+        Assert.That(resultMutable, Does.Contain("List<int> Scores"));
+    }
+
+    [Test]
+    public void ShouldGenerateMutableWithImmutableListProperty()
+    {
+        // Arrange
+        string input = """
+            using System.Collections.Immutable;
+            using Mutty;
+            
+            namespace Mutty.Tests;
+            
+            [MutableGeneration]
+            public record StudentWithTags(string Name, ImmutableList<string> Tags);
+            """;
+
+        // Act
+        string[] generatedOutputs = GetGeneratedOutput(input);
+        string resultMutable = generatedOutputs.First(x => x.Contains("class MutableStudentWithTags"));
+
+        // Assert
+        Assert.That(resultMutable, Does.Contain("List<string> Tags"));
+    }
+
+    [Test]
+    public void ShouldGenerateMutableWithImmutableHashSetProperty()
+    {
+        // Arrange
+        string input = """
+            using System.Collections.Immutable;
+            using Mutty;
+            
+            namespace Mutty.Tests;
+            
+            [MutableGeneration]
+            public record StudentWithUniqueIds(string Name, ImmutableHashSet<int> UniqueIds);
+            """;
+
+        // Act
+        string[] generatedOutputs = GetGeneratedOutput(input);
+        string resultMutable = generatedOutputs.First(x => x.Contains("class MutableStudentWithUniqueIds"));
+
+        // Assert
+        Assert.That(resultMutable, Does.Contain("HashSet<int> UniqueIds"));
+    }
+
+    [Test]
+    public void ShouldGenerateMutableWithImmutableSortedSetProperty()
+    {
+        // Arrange
+        string input = """
+            using System.Collections.Immutable;
+            using Mutty;
+            
+            namespace Mutty.Tests;
+            
+            [MutableGeneration]
+            public record StudentWithSortedScores(string Name, ImmutableSortedSet<int> SortedScores);
+            """;
+
+        // Act
+        string[] generatedOutputs = GetGeneratedOutput(input);
+        string resultMutable = generatedOutputs.First(x => x.Contains("class MutableStudentWithSortedScores"));
+
+        // Assert
+        Assert.That(resultMutable, Does.Contain("SortedSet<int> SortedScores"));
+    }
+
+    [Test]
+    public void ShouldGenerateMutableWithMultipleArrayAndListTypes()
+    {
+        // Arrange
+        string input = """
+            using System.Collections.Immutable;
+            using Mutty;
+            
+            namespace Mutty.Tests;
+            
+            [MutableGeneration]
+            public record ComplexStudent(
+                string Name,
+                ImmutableArray<int> Scores,
+                ImmutableList<string> Tags,
+                ImmutableHashSet<string> Categories);
+            """;
+
+        // Act
+        string[] generatedOutputs = GetGeneratedOutput(input);
+        string resultMutable = generatedOutputs.First(x => x.Contains("class MutableComplexStudent"));
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(resultMutable, Does.Contain("List<int> Scores"));
+            Assert.That(resultMutable, Does.Contain("List<string> Tags"));
+            Assert.That(resultMutable, Does.Contain("HashSet<string> Categories"));
+        });
+    }
+
+    private static string[] GetGeneratedOutput(string sourceCode)
+    {
+        SyntaxTree syntaxTree = CSharpSyntaxTree.ParseText(sourceCode);
+        IEnumerable<MetadataReference> references = AppDomain.CurrentDomain.GetAssemblies()
+            .Where(static assembly => !assembly.IsDynamic)
+            .Select(static assembly => MetadataReference.CreateFromFile(assembly.Location))
+            .Cast<MetadataReference>()
+            .Concat([MetadataReference.CreateFromFile(typeof(MutableGenerationAttribute).Assembly.Location)]);
+
+        CSharpCompilation compilation = CSharpCompilation.Create(
+            "SourceGeneratorTests",
+            [syntaxTree],
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        // Source Generator to test
+        Attributes attributesGenerator = new();
+        MutableRecordGenerator mutableRecordGenerator = new();
+        MutableExtensionsGenerator mutableExtensionsGenerator = new();
+
+        _ = CSharpGeneratorDriver.Create(attributesGenerator, mutableRecordGenerator, mutableExtensionsGenerator)
+            .RunGeneratorsAndUpdateCompilation(
+                compilation,
+                out Compilation outputCompilation,
+                out ImmutableArray<Diagnostic> diagnostics);
+
+        // Ensure no compilation errors
+        Assert.That(
+            diagnostics.Where(static d => d.Severity == DiagnosticSeverity.Error),
+            Is.Empty);
+
+        string[] generatedOutput = outputCompilation
+            .SyntaxTrees
+            .Skip(1)
+            .Select(static tree => tree.ToString())
+            .ToArray();
+
+        return generatedOutput;
+    }
+}

--- a/src/tests/Mutty.Tests/Mutty.Tests.csproj
+++ b/src/tests/Mutty.Tests/Mutty.Tests.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
-    <NoWarn>SA0001;SA1402;SA1600;IDE0005</NoWarn>
+    <NoWarn>SA0001;SA1402;SA1600;IDE0005;RCS1264;RCS1051;RCS1248</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/tests/Mutty.Tests/PropertyModelTests.cs
+++ b/src/tests/Mutty.Tests/PropertyModelTests.cs
@@ -1,0 +1,150 @@
+// Copyright (c) 2020-2024 Atypical Consulting SRL. All rights reserved.
+// Atypical Consulting SRL licenses this file to you under the Apache 2.0 license.
+// See the LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Mutty.Models;
+using NUnit.Framework;
+
+namespace Mutty.Tests;
+
+/// <summary>
+/// Tests for PropertyModel to improve coverage of property type detection.
+/// </summary>
+public class PropertyModelTests
+{
+    [Test]
+    public void PropertyModel_ShouldDetectSimpleProperty()
+    {
+        // Arrange & Act
+        IPropertySymbol? propertySymbol = GetPropertySymbol("public string Name { get; }", "Name");
+        PropertyModel? model = propertySymbol is not null ? new PropertyModel(propertySymbol) : null;
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(model, Is.Not.Null);
+            Assert.That(model!.Name, Is.EqualTo("Name"));
+            Assert.That(model.Type, Is.EqualTo("string"));
+            Assert.That(model.PropertyType, Is.EqualTo(PropertyType.Other));
+        });
+    }
+
+    [Test]
+    public void PropertyModel_ShouldDetectImmutableArrayProperty()
+    {
+        // Arrange & Act
+        IPropertySymbol? propertySymbol = GetPropertySymbol(
+            "public System.Collections.Immutable.ImmutableArray<int> Items { get; }",
+            "Items");
+        PropertyModel? model = propertySymbol is not null ? new PropertyModel(propertySymbol) : null;
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(model, Is.Not.Null);
+            Assert.That(model!.Name, Is.EqualTo("Items"));
+            Assert.That(model.PropertyType, Is.EqualTo(PropertyType.ImmutableCollection));
+        });
+    }
+
+    [Test]
+    public void PropertyModel_ShouldDetectImmutableListProperty()
+    {
+        // Arrange & Act
+        IPropertySymbol? propertySymbol = GetPropertySymbol(
+            "public System.Collections.Immutable.ImmutableList<string> Tags { get; }",
+            "Tags");
+        PropertyModel? model = propertySymbol is not null ? new PropertyModel(propertySymbol) : null;
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(model, Is.Not.Null);
+            Assert.That(model!.Name, Is.EqualTo("Tags"));
+            Assert.That(model.PropertyType, Is.EqualTo(PropertyType.ImmutableCollection));
+        });
+    }
+
+    [Test]
+    public void PropertyModel_ShouldDetectImmutableHashSetProperty()
+    {
+        // Arrange & Act
+        IPropertySymbol? propertySymbol = GetPropertySymbol(
+            "public System.Collections.Immutable.ImmutableHashSet<int> UniqueIds { get; }",
+            "UniqueIds");
+        PropertyModel? model = propertySymbol is not null ? new PropertyModel(propertySymbol) : null;
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(model, Is.Not.Null);
+            Assert.That(model!.Name, Is.EqualTo("UniqueIds"));
+            Assert.That(model.PropertyType, Is.EqualTo(PropertyType.ImmutableCollection));
+        });
+    }
+
+    [Test]
+    public void PropertyModel_ShouldDetectImmutableDictionaryProperty()
+    {
+        // Arrange & Act
+        IPropertySymbol? propertySymbol = GetPropertySymbol(
+            "public System.Collections.Immutable.ImmutableDictionary<string, int> Map { get; }",
+            "Map");
+        PropertyModel? model = propertySymbol is not null ? new PropertyModel(propertySymbol) : null;
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(model, Is.Not.Null);
+            Assert.That(model!.Name, Is.EqualTo("Map"));
+            Assert.That(model.PropertyType, Is.EqualTo(PropertyType.ImmutableCollection));
+        });
+    }
+
+    [Test]
+    public void PropertyModel_ShouldDetectNullableProperty()
+    {
+        // Arrange & Act
+        IPropertySymbol? propertySymbol = GetPropertySymbol("public string? OptionalName { get; }", "OptionalName");
+        PropertyModel? model = propertySymbol is not null ? new PropertyModel(propertySymbol) : null;
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(model, Is.Not.Null);
+            Assert.That(model!.Name, Is.EqualTo("OptionalName"));
+        });
+    }
+
+    private static IPropertySymbol? GetPropertySymbol(string propertyDeclaration, string propertyName)
+    {
+        string code = $@"
+using System.Collections.Immutable;
+
+namespace TestNamespace
+{{
+    public class TestClass
+    {{
+        {propertyDeclaration}
+    }}
+}}";
+
+        SyntaxTree syntaxTree = CSharpSyntaxTree.ParseText(code);
+        IEnumerable<MetadataReference> references = AppDomain.CurrentDomain.GetAssemblies()
+            .Where(static assembly => !assembly.IsDynamic)
+            .Select(static assembly => MetadataReference.CreateFromFile(assembly.Location));
+
+        CSharpCompilation compilation = CSharpCompilation.Create(
+            "TestCompilation",
+            [syntaxTree],
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        SemanticModel? semanticModel = compilation.GetSemanticModel(syntaxTree);
+        INamedTypeSymbol? typeSymbol = compilation.GetTypeByMetadataName("TestNamespace.TestClass");
+
+        return typeSymbol?.GetMembers(propertyName).OfType<IPropertySymbol>().FirstOrDefault();
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds comprehensive test coverage for previously untested areas of the Mutty source generator, achieving a **+8.9% increase in line coverage** and **+6.34% increase in branch coverage**.

## Coverage Improvement

- **Before**: 85.71% line coverage, 67.6% branch coverage
- **After**: 94.61% line coverage, 73.94% branch coverage
- **Total tests**: 64 → 80 (+16 new tests)

## Changes

### New Test Files

1. **CollectionPropertyTests.cs** - Tests for immutable collection property generation
   - ImmutableArray → List conversion
   - ImmutableList → List conversion
   - ImmutableHashSet → HashSet conversion
   - ImmutableSortedSet → SortedSet conversion
   - Multiple collection types in single record

2. **BuiltInTypeTests.cs** - Tests for built-in .NET type handling
   - DateTime, DateTimeOffset, Guid
   - Decimal, double, float
   - Boolean properties
   - All numeric types (byte, short, int, long, etc.)

3. **PropertyModelTests.cs** - Tests for PropertyModel type detection
   - Simple property detection
   - Immutable collection type detection (Array, List, HashSet, Dictionary)
   - Nullable reference type handling

### Modified Files

- **Mutty.Tests.csproj**: Added RCS1264, RCS1051, RCS1248 to NoWarn to align with existing test code style

## Areas Covered

This PR specifically targets and tests:
-  - previously 0% coverage
-  - previously 0% coverage
-  - previously 0% coverage
-  edge cases
- Various branch conditions in generators

## Testing

All 80 tests pass successfully:
```
Passed!  - Failed: 0, Passed: 80, Skipped: 0, Total: 80
```

## Notes

- Tests avoid ImmutableDictionary and ImmutableSortedDictionary as they currently have a generator bug (creates `Dictionary<Mutablestring, T>` instead of `Dictionary<string, T>`)
- This could be addressed in a future PR

Closes #78 (if exists) or contributes to test coverage improvement goals.