### PR TITLE
fix(build): remove deprecated SuppressBuildProjectCheck parameter

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -76,7 +76,7 @@ class Build : NukeBuild
     [GitRepository]
     readonly GitRepository GitRepository;
     
-    [Solution(SuppressBuildProjectCheck = true, GenerateProjects = true)]
+    [Solution(GenerateProjects = true)]
     readonly Solution Solution;
     
     const string MainBranch = "main";


### PR DESCRIPTION
## Problem
The CI build on main was failing with:
```
error CS0246: The type or namespace name 'SuppressBuildProjectCheck' could not be found
```

## Root Cause
The `SuppressBuildProjectCheck` parameter was removed/deprecated in NUKE v10.1.0 (introduced in PR #75).

## Solution
Removed the deprecated parameter from the `[Solution]` attribute in `build/Build.cs`.

## Testing
✅ Build compiles successfully locally
✅ NUKE targets execute correctly

## Changes
- Removed `SuppressBuildProjectCheck = true` from line 79 of `build/Build.cs`

Closes #
Related: #75 (NUKE v10 upgrade)