### PR TITLE
chore: migrate to .NET 10 (remove all .NET 9 references)

### DIFF
--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -46,12 +46,12 @@ jobs:
             .nuke/temp
             ~/.nuget/packages
           key: ${{ runner.os }}-${{ hashFiles('**/global.json', '**/*.csproj', '**/Directory.Packages.props') }}
-      - name: Setup .NET 9 runtime
+      - name: Setup .NET 10 runtime
         run: |
-          # Install .NET 9 runtime to NUKE's dotnet location after it's been set up
+          # Install .NET 10 runtime to NUKE's dotnet location after it's been set up
           DOTNET_INSTALL_DIR=".nuke/temp/dotnet-unix"
           mkdir -p "$DOTNET_INSTALL_DIR"
-          curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --runtime dotnet --channel 9.0 --install-dir "$DOTNET_INSTALL_DIR"
+          curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --runtime dotnet --channel 10.0 --install-dir "$DOTNET_INSTALL_DIR"
       - name: 'Run: Pack'
         run: ./build.cmd Pack
         env:

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -69,7 +69,7 @@ class Build : NukeBuild
     [OctoVersion(
         AutoDetectBranch = true,
         UpdateBuildNumber = true,
-        Framework = "net9.0",
+        Framework = "net10.0",
         Major = 1)]
     readonly OctoVersionInfo OctoVersionInfo;
 


### PR DESCRIPTION
## Changes
- ✅ global.json → SDK 10.0.103 (already done)
- ✅ All .csproj → TargetFramework net10.0 (already done)
- ✅ Directory.Packages.props → Microsoft.* packages 10.0.x (already done)
- ✅ build/Build.cs → Framework net9.0 → net10.0
- ✅ GitHub Actions → .NET 9 runtime → .NET 10 runtime
- ✅ Documentation → No version-specific requirements

## Verification
- [x] dotnet restore → success
- [x] dotnet build → 0 warnings, 0 errors
- [x] dotnet test → all 80 tests pass
- [x] dotnet pack → success
- [x] No .NET 9 references remain in repo

## Breaking Changes
None. This is a build/tooling update only.

---
**Philippe's directive:** "Plus aucune mention de .NET9 ne doit se trouver dans le repository"

✅ **Mission complete** — Mutty is now 100% .NET 10.