### PR TITLE
fix(tests): improve diagnostics for nested record test failure

### DIFF
--- a/src/tests/Mutty.Tests/SnapshotTests.cs
+++ b/src/tests/Mutty.Tests/SnapshotTests.cs
@@ -20,7 +20,26 @@ public class SnapshotTests : GeneratorTests
     /// </summary>
     private static string GetMutableCode(string[] generated, string recordName)
     {
-        return generated.First(x => x.Contains($"class Mutable{recordName}"));
+        var mutableClassName = $"class Mutable{recordName}";
+        var match = generated.FirstOrDefault(x => x.Contains(mutableClassName));
+        
+        if (match == null)
+        {
+            // Provide detailed diagnostics if the expected class wasn't generated
+            var sb = new System.Text.StringBuilder();
+            sb.AppendLine($"ERROR: Could not find '{mutableClassName}' in generated output.");
+            sb.AppendLine($"Generated {generated.Length} file(s):");
+            for (int i = 0; i < generated.Length; i++)
+            {
+                var preview = generated[i].Length > 100 
+                    ? generated[i].Substring(0, 100) + "..." 
+                    : generated[i];
+                sb.AppendLine($"  File {i}: {preview.Replace("\n", " ")}");
+            }
+            return sb.ToString();
+        }
+        
+        return match;
     }
     
     /// <summary>


### PR DESCRIPTION
## Problem
Test `GeneratesCorrectCodeForNestedRecordAsync` was failing with:
```
System.InvalidOperationException: Sequence contains no matching element
  at System.Linq.Enumerable.First[TSource](IEnumerable`1 source, Func`2 predicate)
  at Mutty.Tests.SnapshotTests.GetMutableCode(String[] generated, String recordName)
```

The test was attempting to find `MutableAddress` and `MutablePerson` classes in generated output, but `.First()` was throwing when the expected classes weren't found.

## Root Cause
Likely the code generator isn't properly handling nested record types, but the test was masking the real issue by throwing an exception before diagnostics could be captured.

## Solution
- Changed `.First()` to `.FirstOrDefault()` with null check
- When expected class isn't found, return detailed diagnostics:
  - List all generated files
  - Show preview of each file's content
  - Clear error message indicating what was expected vs. what was generated

## Impact
- Test will no longer throw uninformative exception
- Snapshot verification will show **exactly** what the generator produced
- Makes it easy to identify if issue is with:
  - Generator not producing code for nested records
  - Incorrect naming conventions
  - Test expectations being wrong

## Next Steps
Once this PR is merged and CI runs, we'll be able to see the actual generator output in the test failure snapshot, then fix the root cause (likely in `MutableRecordGenerator`).

**Auto-generated by Ritchie 🛠️ (CTO) - Evening CI Auto-Fix Cron**