### PR TITLE
fix(tests): add blank line after for loop closing brace (RCS0008)

### DIFF
--- a/src/tests/Mutty.Tests/SnapshotTests.cs
+++ b/src/tests/Mutty.Tests/SnapshotTests.cs
@@ -36,6 +36,7 @@ public class SnapshotTests : GeneratorTests
                     : generated[i];
                 sb.AppendLine($"  File {i}: {preview.Replace("\n", " ")}");
             }
+
             return sb.ToString();
         }
 


### PR DESCRIPTION
## Issue
CI workflow 'continuous' was failing with Roslynator RCS0008 error:
```
error RCS0008: Add blank line between closing brace and next statement
Location: src/tests/Mutty.Tests/SnapshotTests.cs(38,14)
```

## Root Cause
Missing blank line between for loop closing brace and return statement in `GetMutableCode` helper method.

## Fix
Added required blank line to comply with Roslynator code style rules.

## Testing
- [x] Builds locally without errors
- [ ] CI should pass after merge

---
**Auto-fix by Ritchie** 🛠️ (CTO Morning CI Health Check)