### PR TITLE
fix(ci): Handle duplicate GitHub release creation gracefully

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -248,29 +248,49 @@ class Build : NukeBuild
             var latestChangeLog = changeLogSectionEntries
                 .Aggregate((c, n) => c + Environment.NewLine + n);
 
-            var newRelease = new NewRelease(releaseTag)
+            // Check if release already exists
+            Release existingRelease = null;
+            try
             {
-                TargetCommitish = GitRepository.Branch,
-                Draft = true,
-                Name = $"v{releaseTag}",
-                Prerelease = !string.IsNullOrEmpty(OctoVersionInfo.PreReleaseTag),
-                Body = latestChangeLog
-            };
+                existingRelease = await GitHubTasks
+                    .GitHubClient
+                    .Repository
+                    .Release
+                    .Get(owner, name, releaseTag);
+                Log.Information("Release {ReleaseTag} already exists, skipping creation", releaseTag);
+            }
+            catch (Octokit.NotFoundException)
+            {
+                // Release doesn't exist, we'll create it
+                Log.Information("Release {ReleaseTag} does not exist, creating new release", releaseTag);
+            }
 
-            var createdRelease = await GitHubTasks
-                .GitHubClient
-                .Repository
-                .Release.Create(owner, name, newRelease);
+            if (existingRelease == null)
+            {
+                var newRelease = new NewRelease(releaseTag)
+                {
+                    TargetCommitish = GitRepository.Branch,
+                    Draft = true,
+                    Name = $"v{releaseTag}",
+                    Prerelease = !string.IsNullOrEmpty(OctoVersionInfo.PreReleaseTag),
+                    Body = latestChangeLog
+                };
 
-            ArtifactsDirectory.GlobFiles(ArtifactsType)
-                .Where(x => !x.Name.EndsWith(ExcludedArtifactsType))
-                .ForEach(async void (x) => await UploadReleaseAssetToGithub(createdRelease, x));
+                var createdRelease = await GitHubTasks
+                    .GitHubClient
+                    .Repository
+                    .Release.Create(owner, name, newRelease);
 
-            await GitHubTasks
-                .GitHubClient
-                .Repository
-                .Release
-                .Edit(owner, name, createdRelease.Id, new ReleaseUpdate { Draft = false });
+                ArtifactsDirectory.GlobFiles(ArtifactsType)
+                    .Where(x => !x.Name.EndsWith(ExcludedArtifactsType))
+                    .ForEach(async void (x) => await UploadReleaseAssetToGithub(createdRelease, x));
+
+                await GitHubTasks
+                    .GitHubClient
+                    .Repository
+                    .Release
+                    .Edit(owner, name, createdRelease.Id, new ReleaseUpdate { Draft = false });
+            }
         });
 
     static async Task UploadReleaseAssetToGithub(Release release, string asset)


### PR DESCRIPTION
## Problem

The `CreateRelease` target in the NUKE build pipeline was failing with:
```
Octokit.ApiValidationException: Validation Failed
{"message":"Validation Failed","errors":[{"resource":"Release","code":"already_exists","field":"tag_name"}]}
```

This happens when the same version (e.g., `1.0.74`) is built multiple times and the GitHub release already exists.

## Solution

Added logic to check if a release already exists before attempting to create it:
1. Try to get the existing release by tag
2. If it exists, skip creation and log the info
3. If it doesn't exist (NotFoundException), proceed with creation as before

## Testing

- [x] Builds successfully
- [x] Handles duplicate releases gracefully
- [x] Does not affect normal release creation flow

## Impact

- ✅ Prevents CI failures on duplicate release attempts
- ✅ Makes the build pipeline more robust and idempotent
- ✅ No breaking changes to existing workflow

---

**Auto-generated by Ritchie (CTO) — Evening CI Health Check**