### PR TITLE
v2 breaking: make the Mutable→record conversion explicit (P13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Breaking
+- The `Mutable{Record}` → `{Record}` conversion is now an **explicit** operator instead of implicit. This prevents hidden allocations (e.g. `record == mutable` silently built a record). Update call sites to an explicit cast `(Record)mutable`, or — preferably — call `mutable.Build()` / `mutable.ToImmutable()`. The `{Record}` → `Mutable{Record}` direction stays implicit.
+
 ### Added
 - `ToImmutable()` instance method on generated wrappers as a discoverable alias for `Build()`.
 - `partial void OnBeforeBuild()` hook on generated wrappers, called at the start of `Build()`, as a validation/normalisation seam.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Immutable Record Mutation Made Easy
 
 - [x] **Automated Mutable Wrappers**: Automatically generates mutable wrapper classes for your immutable records using Roslyn's Incremental Source Generation.
 - [x] **Deep Nesting Support**: Easily handle complex nested structures without tedious and error-prone manual code.
-- [x] **Immutable to Mutable Conversion**: Seamlessly switch between immutable and mutable versions of your records using implicit conversions.
+- [x] **Immutable to Mutable Conversion**: An implicit conversion creates a mutable draft from a record; converting back is an explicit cast (or call `Build()`/`ToImmutable()`) so the allocation is never hidden.
 - [x] **Ideal for Flux Architecture**: Works great with Flux architecture, allowing you to manage state changes in a predictable and immutable way.
 - [x] **Helper Methods**:
     - [x] Provides a `Produce` method to apply mutations to your immutable records using the generated mutable wrappers.
@@ -146,9 +146,10 @@ namespace Mutty.ConsoleApp
         }
 
         /// <summary>
-        /// Performs an implicit conversion from <see cref="MutableStudent"/> to <see cref="Student"/>.
+        /// Performs an explicit conversion from <see cref="MutableStudent"/> to <see cref="Student"/>.
         /// </summary>
-        public static implicit operator Student(MutableStudent mutable)
+        /// <remarks>Explicit because it allocates a new record; prefer <see cref="Build"/>.</remarks>
+        public static explicit operator Student(MutableStudent mutable)
         {
             return mutable.Build();
         }
@@ -258,7 +259,7 @@ To use Mutty in your project:
 
 - **Immutable by Default**: Use immutable records for your core data models to ensure thread safety and prevent unintended side effects.
 - **Mutate with Care**: Use the generated mutable wrappers when you need to make changes, but remember to always convert back to the immutable form before exposing the data.
-- **Leverage the Implicit Conversion**: Mutty provides implicit conversions between the immutable and mutable versions of your records, making it easy to switch between the two.
+- **Convert Deliberately**: Creating a mutable draft from a record is implicit, but converting back is an explicit cast — prefer calling `Build()` (or its `ToImmutable()` alias) so the allocation is obvious at the call site.
 
 ### Contributing
 

--- a/src/library/Mutty/Templates/MutableWrapperTemplate.cs
+++ b/src/library/Mutty/Templates/MutableWrapperTemplate.cs
@@ -60,7 +60,7 @@ public class MutableWrapperTemplate(RecordModel tokens) : IndentedCodeBuilder
             GenerateToImmutableAlias();
             GenerateOnBeforeBuildHook();
             GenerateImplicitOperatorToMutable();
-            GenerateImplicitOperatorToRecord();
+            GenerateExplicitOperatorToRecord();
             GenerateProperties();
         });
     }
@@ -134,7 +134,13 @@ public class MutableWrapperTemplate(RecordModel tokens) : IndentedCodeBuilder
                         {
                             case PropertyType.Record:
                                 {
-                                    Line($"{property.Name} = this.{property.Name},");
+                                    // Materialise the nested wrapper explicitly rather than relying on the
+                                    // (now explicit) mutable-to-record conversion operator.
+                                    bool isNullable = property.Type.EndsWith("?", StringComparison.Ordinal);
+                                    string build = (isNullable)
+                                        ? $"this.{property.Name}?.Build()"
+                                        : $"this.{property.Name}.Build()";
+                                    Line($"{property.Name} = {build},");
                                     break;
                                 }
                             case PropertyType.ImmutableCollection:
@@ -505,11 +511,12 @@ public class MutableWrapperTemplate(RecordModel tokens) : IndentedCodeBuilder
         Braces(() => Line($"return new {_mutableRecordName}(record);"));
     }
 
-    private void GenerateImplicitOperatorToRecord()
+    private void GenerateExplicitOperatorToRecord()
     {
         EmptyLine();
-        Summary($"Performs an implicit conversion from <see cref=\"{_mutableRecordName}\"/> to <see cref=\"{_recordName}\"/>.");
-        Line($"public static implicit operator {_recordName}({_mutableRecordName} mutable)");
+        Summary($"Performs an explicit conversion from <see cref=\"{_mutableRecordName}\"/> to <see cref=\"{_recordName}\"/>.");
+        Line("/// <remarks>Explicit because it allocates a new record; prefer <see cref=\"Build\"/>.</remarks>");
+        Line($"public static explicit operator {_recordName}({_mutableRecordName} mutable)");
         Braces(() => Line("return mutable.Build();"));
     }
 }

--- a/src/tests/Mutty.Tests/EndToEndCompilationTests.cs
+++ b/src/tests/Mutty.Tests/EndToEndCompilationTests.cs
@@ -252,6 +252,61 @@ public class EndToEndCompilationTests : GeneratorTests
     }
 
     [Test]
+    public void MutableToRecord_ExplicitCastCompilesAndRoundTrips()
+    {
+        string source =
+            """
+            using Mutty;
+
+            namespace Demo
+            {
+                [MutableGeneration]
+                public partial record Point(int X, int Y);
+
+                public static class PointUsage
+                {
+                    public static Point ViaExplicit(MutablePoint m) => (Point)m;
+                }
+            }
+            """;
+
+        Assembly assembly = CompileToAssembly(source);
+
+        Type pointType = assembly.GetType("Demo.Point").ShouldNotBeNull();
+        object point = Activator.CreateInstance(pointType, 1, 2)!;
+        object mutable = ToMutable(assembly, "Demo.Point", point);
+
+        Type usage = assembly.GetType("Demo.PointUsage").ShouldNotBeNull();
+        object result = usage.GetMethod("ViaExplicit")!.Invoke(null, [mutable])!;
+
+        pointType.GetProperty("X")!.GetValue(result).ShouldBe(1);
+        pointType.GetProperty("Y")!.GetValue(result).ShouldBe(2);
+    }
+
+    [Test]
+    public void MutableToRecord_ImplicitConversionDoesNotCompile()
+    {
+        // The mutable-to-record conversion is explicit; assigning a mutable to a record must not compile.
+        string source =
+            """
+            using Mutty;
+
+            namespace Demo
+            {
+                [MutableGeneration]
+                public partial record Point(int X, int Y);
+
+                public static class PointUsage
+                {
+                    public static Point ViaImplicit(MutablePoint m) => m;
+                }
+            }
+            """;
+
+        Should.Throw<InvalidOperationException>(() => CompileToAssembly(source));
+    }
+
+    [Test]
     public void DefaultImmutableArray_DoesNotThrowOnWrap()
     {
         // A record constructed with default(ImmutableArray<T>) must wrap without throwing

--- a/src/tests/Mutty.Tests/MutableRecordGeneratorTests.cs
+++ b/src/tests/Mutty.Tests/MutableRecordGeneratorTests.cs
@@ -186,9 +186,10 @@ public class MutableRecordGeneratorTests
                     }
 
                     /// <summary>
-                    /// Performs an implicit conversion from <see cref="MutableStudentDetails"/> to <see cref="StudentDetails"/>.
+                    /// Performs an explicit conversion from <see cref="MutableStudentDetails"/> to <see cref="StudentDetails"/>.
                     /// </summary>
-                    public static implicit operator StudentDetails(MutableStudentDetails mutable)
+                    /// <remarks>Explicit because it allocates a new record; prefer <see cref="Build"/>.</remarks>
+                    public static explicit operator StudentDetails(MutableStudentDetails mutable)
                     {
                         return mutable.Build();
                     }

--- a/src/tests/Mutty.Tests/SnapshotTests.AllPrimitiveTypes.verified.txt
+++ b/src/tests/Mutty.Tests/SnapshotTests.AllPrimitiveTypes.verified.txt
@@ -88,9 +88,10 @@ namespace Mutty.Tests
         }
 
         /// <summary>
-        /// Performs an implicit conversion from <see cref="MutableAllTypes"/> to <see cref="AllTypes"/>.
+        /// Performs an explicit conversion from <see cref="MutableAllTypes"/> to <see cref="AllTypes"/>.
         /// </summary>
-        public static implicit operator AllTypes(MutableAllTypes mutable)
+        /// <remarks>Explicit because it allocates a new record; prefer <see cref="Build"/>.</remarks>
+        public static explicit operator AllTypes(MutableAllTypes mutable)
         {
             return mutable.Build();
         }

--- a/src/tests/Mutty.Tests/SnapshotTests.BasicRecord.verified.txt
+++ b/src/tests/Mutty.Tests/SnapshotTests.BasicRecord.verified.txt
@@ -64,9 +64,10 @@ namespace Mutty.Tests
         }
 
         /// <summary>
-        /// Performs an implicit conversion from <see cref="MutablePerson"/> to <see cref="Person"/>.
+        /// Performs an explicit conversion from <see cref="MutablePerson"/> to <see cref="Person"/>.
         /// </summary>
-        public static implicit operator Person(MutablePerson mutable)
+        /// <remarks>Explicit because it allocates a new record; prefer <see cref="Build"/>.</remarks>
+        public static explicit operator Person(MutablePerson mutable)
         {
             return mutable.Build();
         }

--- a/src/tests/Mutty.Tests/SnapshotTests.ComplexNestedGeneric.verified.txt
+++ b/src/tests/Mutty.Tests/SnapshotTests.ComplexNestedGeneric.verified.txt
@@ -64,9 +64,10 @@ namespace Mutty.Tests
         }
 
         /// <summary>
-        /// Performs an implicit conversion from <see cref="MutableComplexData"/> to <see cref="ComplexData"/>.
+        /// Performs an explicit conversion from <see cref="MutableComplexData"/> to <see cref="ComplexData"/>.
         /// </summary>
-        public static implicit operator ComplexData(MutableComplexData mutable)
+        /// <remarks>Explicit because it allocates a new record; prefer <see cref="Build"/>.</remarks>
+        public static explicit operator ComplexData(MutableComplexData mutable)
         {
             return mutable.Build();
         }

--- a/src/tests/Mutty.Tests/SnapshotTests.MixedCollectionsWithBasicTypes.verified.txt
+++ b/src/tests/Mutty.Tests/SnapshotTests.MixedCollectionsWithBasicTypes.verified.txt
@@ -66,9 +66,10 @@ namespace Mutty.Tests
         }
 
         /// <summary>
-        /// Performs an implicit conversion from <see cref="MutableMixedData"/> to <see cref="MixedData"/>.
+        /// Performs an explicit conversion from <see cref="MutableMixedData"/> to <see cref="MixedData"/>.
         /// </summary>
-        public static implicit operator MixedData(MutableMixedData mutable)
+        /// <remarks>Explicit because it allocates a new record; prefer <see cref="Build"/>.</remarks>
+        public static explicit operator MixedData(MutableMixedData mutable)
         {
             return mutable.Build();
         }

--- a/src/tests/Mutty.Tests/SnapshotTests.NestedRecord.verified.txt
+++ b/src/tests/Mutty.Tests/SnapshotTests.NestedRecord.verified.txt
@@ -66,9 +66,10 @@ namespace Mutty.Tests
         }
 
         /// <summary>
-        /// Performs an implicit conversion from <see cref="MutableAddress"/> to <see cref="Address"/>.
+        /// Performs an explicit conversion from <see cref="MutableAddress"/> to <see cref="Address"/>.
         /// </summary>
-        public static implicit operator Address(MutableAddress mutable)
+        /// <remarks>Explicit because it allocates a new record; prefer <see cref="Build"/>.</remarks>
+        public static explicit operator Address(MutableAddress mutable)
         {
             return mutable.Build();
         }
@@ -125,7 +126,7 @@ namespace Mutty.Tests
             return _record with
             {
                 Name = this.Name,
-                HomeAddress = this.HomeAddress,
+                HomeAddress = this.HomeAddress.Build(),
             };
         }
 
@@ -152,9 +153,10 @@ namespace Mutty.Tests
         }
 
         /// <summary>
-        /// Performs an implicit conversion from <see cref="MutablePerson"/> to <see cref="Person"/>.
+        /// Performs an explicit conversion from <see cref="MutablePerson"/> to <see cref="Person"/>.
         /// </summary>
-        public static implicit operator Person(MutablePerson mutable)
+        /// <remarks>Explicit because it allocates a new record; prefer <see cref="Build"/>.</remarks>
+        public static explicit operator Person(MutablePerson mutable)
         {
             return mutable.Build();
         }

--- a/src/tests/Mutty.Tests/SnapshotTests.NullableReferenceTypes.verified.txt
+++ b/src/tests/Mutty.Tests/SnapshotTests.NullableReferenceTypes.verified.txt
@@ -66,9 +66,10 @@ namespace Mutty.Tests
         }
 
         /// <summary>
-        /// Performs an implicit conversion from <see cref="MutableUser"/> to <see cref="User"/>.
+        /// Performs an explicit conversion from <see cref="MutableUser"/> to <see cref="User"/>.
         /// </summary>
-        public static implicit operator User(MutableUser mutable)
+        /// <remarks>Explicit because it allocates a new record; prefer <see cref="Build"/>.</remarks>
+        public static explicit operator User(MutableUser mutable)
         {
             return mutable.Build();
         }

--- a/src/tests/Mutty.Tests/SnapshotTests.NullableValueTypes.verified.txt
+++ b/src/tests/Mutty.Tests/SnapshotTests.NullableValueTypes.verified.txt
@@ -66,9 +66,10 @@ namespace Mutty.Tests
         }
 
         /// <summary>
-        /// Performs an implicit conversion from <see cref="MutableStats"/> to <see cref="Stats"/>.
+        /// Performs an explicit conversion from <see cref="MutableStats"/> to <see cref="Stats"/>.
         /// </summary>
-        public static implicit operator Stats(MutableStats mutable)
+        /// <remarks>Explicit because it allocates a new record; prefer <see cref="Build"/>.</remarks>
+        public static explicit operator Stats(MutableStats mutable)
         {
             return mutable.Build();
         }

--- a/src/tests/Mutty.Tests/SnapshotTests.RecordWithImmutableDictionary.verified.txt
+++ b/src/tests/Mutty.Tests/SnapshotTests.RecordWithImmutableDictionary.verified.txt
@@ -64,9 +64,10 @@ namespace Mutty.Tests
         }
 
         /// <summary>
-        /// Performs an implicit conversion from <see cref="MutableConfiguration"/> to <see cref="Configuration"/>.
+        /// Performs an explicit conversion from <see cref="MutableConfiguration"/> to <see cref="Configuration"/>.
         /// </summary>
-        public static implicit operator Configuration(MutableConfiguration mutable)
+        /// <remarks>Explicit because it allocates a new record; prefer <see cref="Build"/>.</remarks>
+        public static explicit operator Configuration(MutableConfiguration mutable)
         {
             return mutable.Build();
         }

--- a/src/tests/Mutty.Tests/SnapshotTests.RecordWithImmutableList.verified.txt
+++ b/src/tests/Mutty.Tests/SnapshotTests.RecordWithImmutableList.verified.txt
@@ -64,9 +64,10 @@ namespace Mutty.Tests
         }
 
         /// <summary>
-        /// Performs an implicit conversion from <see cref="MutableTeam"/> to <see cref="Team"/>.
+        /// Performs an explicit conversion from <see cref="MutableTeam"/> to <see cref="Team"/>.
         /// </summary>
-        public static implicit operator Team(MutableTeam mutable)
+        /// <remarks>Explicit because it allocates a new record; prefer <see cref="Build"/>.</remarks>
+        public static explicit operator Team(MutableTeam mutable)
         {
             return mutable.Build();
         }

--- a/src/tests/Mutty.Tests/SnapshotTests.RecordWithMultipleCollections.verified.txt
+++ b/src/tests/Mutty.Tests/SnapshotTests.RecordWithMultipleCollections.verified.txt
@@ -66,9 +66,10 @@ namespace Mutty.Tests
         }
 
         /// <summary>
-        /// Performs an implicit conversion from <see cref="MutableDataSet"/> to <see cref="DataSet"/>.
+        /// Performs an explicit conversion from <see cref="MutableDataSet"/> to <see cref="DataSet"/>.
         /// </summary>
-        public static implicit operator DataSet(MutableDataSet mutable)
+        /// <remarks>Explicit because it allocates a new record; prefer <see cref="Build"/>.</remarks>
+        public static explicit operator DataSet(MutableDataSet mutable)
         {
             return mutable.Build();
         }


### PR DESCRIPTION
First of the **v2.0.0 breaking changes**. Follow-up to #153 and #154.

## What changes
The generated `Mutable{Record}` → `{Record}` conversion is now an **explicit** operator instead of implicit. Previously, anywhere a record was expected, a mutable wrapper silently `Build()`-ed a new record — most insidiously `record == mutable`, which allocated a fresh record on every comparison.

- Wrappers emit `public static explicit operator {Record}(...)`.
- Generated nested `Build()` now calls `this.Prop.Build()` (and `?.Build()` for nullable nested records) explicitly, so nested materialization no longer depends on the operator.
- The `{Record}` → `Mutable{Record}` direction stays **implicit** (creating a draft is intentional and cheap to reason about).

## Migration
Replace implicit conversions with `mutable.Build()` / `mutable.ToImmutable()`, or an explicit `(Record)mutable` cast.

## Tests
- New E2E test: the explicit cast compiles and round-trips.
- New E2E test: the implicit assignment **no longer compiles** (guards the breaking behavior).
- README + CHANGELOG (with a Breaking section) updated; snapshots + exact-output test re-accepted.

**124 tests passing, 0 skipped.**

## Still on the v2 list
- **P20** — defensive copy / diagnostic for plain `T[]` & `IReadOnlyList<T>` members (currently aliased by reference).
- **P28** — fluent `Produce` / `With*` methods.
- **P25** — edge-case tests (required / init-only / positional records).
- **P16** — FQN+arity hint names (low priority).

🤖 Generated with [Claude Code](https://claude.com/claude-code)