### PR TITLE
v2: array/read-only-collection copying (P20) + fluent With setters (P28)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `Mutable{Record}` → `{Record}` conversion is now an **explicit** operator instead of implicit. This prevents hidden allocations (e.g. `record == mutable` silently built a record). Update call sites to an explicit cast `(Record)mutable`, or — preferably — call `mutable.Build()` / `mutable.ToImmutable()`. The `{Record}` → `Mutable{Record}` direction stays implicit.
 
 ### Added
+- Chainable `With{Property}` fluent setters on generated wrappers, e.g. `student.Produce(m => m.WithName("Jane").WithAge(30))`.
+- Support for plain array (`T[]`) and read-only collection (`IReadOnlyList<T>` / `IReadOnlyCollection<T>`) properties: arrays are defensively copied; read-only collections are exposed as a mutable `List<T>`.
 - `ToImmutable()` instance method on generated wrappers as a discoverable alias for `Build()`.
 - `partial void OnBeforeBuild()` hook on generated wrappers, called at the start of `Build()`, as a validation/normalisation seam.
 - BenchmarkDotNet harness (`Mutty.Benchmarks`) measuring cold vs incremental generator runs.

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Immutable Record Mutation Made Easy
     - [x] Provides a `Produce` method to apply mutations to your immutable records using the generated mutable wrappers.
     - [x] Also includes `CreateDraft` and `FinishDraft` methods for more granular control...
     - [x] ...and `AsMutable` and `ToImmutable` extension methods for collections.
+- [x] **Fluent Mutation**: Each wrapper exposes chainable `With{Property}` setters, e.g. `student.Produce(m => m.WithName("Jane").WithAge(30))`.
 
 ## How Mutty Works
 

--- a/src/library/Mutty/Models/PropertyModel.cs
+++ b/src/library/Mutty/Models/PropertyModel.cs
@@ -76,11 +76,27 @@ public sealed record PropertyModel(
             return PropertyType.Record;
         }
 
+        // Plain arrays are mutable and shared by reference; expose a defensive copy.
+        if (type is IArrayTypeSymbol)
+        {
+            return PropertyType.Array;
+        }
+
         // Detect immutable collections by their originating definition's namespace.
         string originalDefinition = type.OriginalDefinition.ToDisplayString();
-        return (originalDefinition.StartsWith("System.Collections.Immutable.", StringComparison.Ordinal))
-            ? PropertyType.ImmutableCollection
-            : PropertyType.Other;
+        if (originalDefinition.StartsWith("System.Collections.Immutable.", StringComparison.Ordinal))
+        {
+            return PropertyType.ImmutableCollection;
+        }
+
+        // Read-only collection interfaces become a mutable List<T>.
+        if (originalDefinition is "System.Collections.Generic.IReadOnlyList<T>"
+            or "System.Collections.Generic.IReadOnlyCollection<T>")
+        {
+            return PropertyType.ReadOnlyCollection;
+        }
+
+        return PropertyType.Other;
     }
 
     private static bool HasMutableGenerationAttribute(ISymbol type)

--- a/src/library/Mutty/Models/PropertyType.cs
+++ b/src/library/Mutty/Models/PropertyType.cs
@@ -20,6 +20,18 @@ public enum PropertyType
     ImmutableCollection,
 
     /// <summary>
+    /// The property is an array (<c>T[]</c>). Exposed as a mutable copy so mutating the wrapper does not
+    /// alias the source record's array.
+    /// </summary>
+    Array,
+
+    /// <summary>
+    /// The property is a read-only collection interface (<c>IReadOnlyList&lt;T&gt;</c> /
+    /// <c>IReadOnlyCollection&lt;T&gt;</c>). Exposed as a mutable <c>List&lt;T&gt;</c>.
+    /// </summary>
+    ReadOnlyCollection,
+
+    /// <summary>
     /// The property is of another type.
     /// </summary>
     Other

--- a/src/library/Mutty/Templates/MutableWrapperTemplate.cs
+++ b/src/library/Mutty/Templates/MutableWrapperTemplate.cs
@@ -62,6 +62,7 @@ public class MutableWrapperTemplate(RecordModel tokens) : IndentedCodeBuilder
             GenerateImplicitOperatorToMutable();
             GenerateExplicitOperatorToRecord();
             GenerateProperties();
+            GenerateWithMethods();
         });
     }
 
@@ -237,6 +238,46 @@ public class MutableWrapperTemplate(RecordModel tokens) : IndentedCodeBuilder
                 default:
                     throw new ArgumentOutOfRangeException();
             }
+        }
+    }
+
+    private void GenerateWithMethods()
+    {
+        foreach (PropertyModel property in _properties)
+        {
+            EmptyLine();
+            Summary($"Sets <see cref=\"{property.Name}\"/> and returns this wrapper so calls can be chained.");
+            Line($"public {_mutableRecordName} With{property.Name}({GetMutablePropertyType(property)} value)");
+            Braces(() =>
+            {
+                Line($"{property.Name} = value;");
+                Line("return this;");
+            });
+        }
+    }
+
+    private string GetMutablePropertyType(PropertyModel property)
+    {
+        switch (property.PropertyType)
+        {
+            case PropertyType.Record:
+                {
+                    bool isNullable = property.Type.EndsWith("?", StringComparison.Ordinal);
+                    string mutableTypeName = property.RecordMutableTypeName!;
+                    return (isNullable) ? $"{mutableTypeName}?" : mutableTypeName;
+                }
+            case PropertyType.ImmutableCollection:
+                {
+                    string mutableType = ConvertImmutableToMutable(property.Type);
+                    string convertedTypeArgs = ConvertGenericTypeArguments(GetMutableItemType(property.Type));
+                    return $"{mutableType}<{convertedTypeArgs}>";
+                }
+            case PropertyType.ReadOnlyCollection:
+                return GetReadOnlyMutableType(property);
+            case PropertyType.Array:
+            case PropertyType.Other:
+            default:
+                return property.Type;
         }
     }
 

--- a/src/library/Mutty/Templates/MutableWrapperTemplate.cs
+++ b/src/library/Mutty/Templates/MutableWrapperTemplate.cs
@@ -84,6 +84,16 @@ public class MutableWrapperTemplate(RecordModel tokens) : IndentedCodeBuilder
                             Line($"{property.Name} = {GenerateCollectionIngestExpression(property)};");
                             break;
                         }
+                    case PropertyType.Array:
+                        {
+                            Line($"{property.Name} = {SequenceCopy($"_record.{property.Name}", property, toArray: true)};");
+                            break;
+                        }
+                    case PropertyType.ReadOnlyCollection:
+                        {
+                            Line($"{property.Name} = {SequenceCopy($"_record.{property.Name}", property, toArray: false)};");
+                            break;
+                        }
                     case PropertyType.Record:
                         {
                             // Handle nullable record types to avoid NullReferenceException
@@ -148,6 +158,16 @@ public class MutableWrapperTemplate(RecordModel tokens) : IndentedCodeBuilder
                                     Line($"{property.Name} = {GenerateCollectionBuildExpression(property)},");
                                     break;
                                 }
+                            case PropertyType.Array:
+                                {
+                                    Line($"{property.Name} = {SequenceCopy($"this.{property.Name}", property, toArray: true)},");
+                                    break;
+                                }
+                            case PropertyType.ReadOnlyCollection:
+                                {
+                                    Line($"{property.Name} = {SequenceCopy($"this.{property.Name}", property, toArray: false)},");
+                                    break;
+                                }
                             case PropertyType.Other:
                                 {
                                     Line($"{property.Name} = this.{property.Name},");
@@ -194,6 +214,19 @@ public class MutableWrapperTemplate(RecordModel tokens) : IndentedCodeBuilder
                 case PropertyType.ImmutableCollection:
                     {
                         GenerateCollectionProperty(property);
+                        break;
+                    }
+                case PropertyType.Array:
+                    {
+                        // Keep the array type; isolation is provided by copying on ingest and build.
+                        Summary($"Gets or sets the {property.Name}.");
+                        Line($"public {property.Type} {property.Name} {{ get; set; }}");
+                        break;
+                    }
+                case PropertyType.ReadOnlyCollection:
+                    {
+                        Summary($"Gets or sets the {property.Name}.");
+                        Line($"public {GetReadOnlyMutableType(property)} {property.Name} {{ get; set; }}");
                         break;
                     }
                 case PropertyType.Other:
@@ -289,6 +322,23 @@ public class MutableWrapperTemplate(RecordModel tokens) : IndentedCodeBuilder
             "ImmutableStack" => $"ImmutableStack.CreateRange({source})",
             _ => $"{source}.ToImmutableList()"
         };
+    }
+
+    private string SequenceCopy(string source, PropertyModel property, bool toArray)
+    {
+        // Defensive copy so the wrapper never aliases the source record's array/collection.
+        // ToArray() preserves T[] members; ToList() materialises read-only interfaces as List<T>.
+        string method = (toArray) ? "ToArray()" : "ToList()";
+        bool isNullable = property.Type.EndsWith("?", StringComparison.Ordinal);
+        return (isNullable) ? $"{source}?.{method}" : $"{source}.{method}";
+    }
+
+    private string GetReadOnlyMutableType(PropertyModel property)
+    {
+        bool isNullable = property.Type.EndsWith("?", StringComparison.Ordinal);
+        string baseType = (isNullable) ? property.Type.TrimEnd('?') : property.Type;
+        string element = GetMutableItemType(baseType);
+        return (isNullable) ? $"List<{element}>?" : $"List<{element}>";
     }
 
     private bool IsListLikeImmutable(string immutableType)

--- a/src/tests/Mutty.Tests/EndToEndCompilationTests.cs
+++ b/src/tests/Mutty.Tests/EndToEndCompilationTests.cs
@@ -307,6 +307,37 @@ public class EndToEndCompilationTests : GeneratorTests
     }
 
     [Test]
+    public void FluentWithMethods_ChainInsideProduce()
+    {
+        string source =
+            """
+            using Mutty;
+
+            namespace Demo
+            {
+                [MutableGeneration]
+                public partial record Student(string Name, int Age);
+
+                public static class Usage
+                {
+                    public static Student Update(Student s) => s.Produce(m => m.WithName("Jane").WithAge(30));
+                }
+            }
+            """;
+
+        Assembly assembly = CompileToAssembly(source);
+
+        Type studentType = assembly.GetType("Demo.Student").ShouldNotBeNull();
+        object student = Activator.CreateInstance(studentType, "John", 20)!;
+
+        Type usage = assembly.GetType("Demo.Usage").ShouldNotBeNull();
+        object updated = usage.GetMethod("Update")!.Invoke(null, [student])!;
+
+        studentType.GetProperty("Name")!.GetValue(updated).ShouldBe("Jane");
+        studentType.GetProperty("Age")!.GetValue(updated).ShouldBe(30);
+    }
+
+    [Test]
     public void ArrayProperty_IsCopiedNotAliased()
     {
         string source = CreateInput("public partial record Tags(string[] Values);");

--- a/src/tests/Mutty.Tests/EndToEndCompilationTests.cs
+++ b/src/tests/Mutty.Tests/EndToEndCompilationTests.cs
@@ -307,6 +307,51 @@ public class EndToEndCompilationTests : GeneratorTests
     }
 
     [Test]
+    public void ArrayProperty_IsCopiedNotAliased()
+    {
+        string source = CreateInput("public partial record Tags(string[] Values);");
+        Assembly assembly = CompileToAssembly(source);
+
+        Type tagsType = assembly.GetType("Mutty.Tests.Tags").ShouldNotBeNull();
+        string[] original = ["a", "b"];
+        // Wrap in object[] so the string[] is one constructor argument, not the argument list.
+        object tags = Activator.CreateInstance(tagsType, new object[] { original })!;
+
+        object mutable = ToMutable(assembly, "Mutty.Tests.Tags", tags);
+        var mutableArray = (string[])mutable.GetType().GetProperty("Values")!.GetValue(mutable)!;
+
+        mutableArray.ShouldNotBeSameAs(original);  // ingest copied
+        mutableArray[0] = "z";
+        original[0].ShouldBe("a");                 // source record not corrupted
+
+        object rebuilt = Build(mutable);
+        var rebuiltArray = (string[])tagsType.GetProperty("Values")!.GetValue(rebuilt)!;
+        rebuiltArray[0].ShouldBe("z");
+        rebuiltArray.ShouldNotBeSameAs(mutableArray);  // build copied
+    }
+
+    [Test]
+    public void ReadOnlyListProperty_IsExposedAsMutableList()
+    {
+        string source = CreateInput("public partial record Bag(System.Collections.Generic.IReadOnlyList<int> Items);");
+        Assembly assembly = CompileToAssembly(source);
+
+        Type bagType = assembly.GetType("Mutty.Tests.Bag").ShouldNotBeNull();
+        object bag = Activator.CreateInstance(bagType, new List<int> { 1, 2 })!;
+
+        object mutable = ToMutable(assembly, "Mutty.Tests.Bag", bag);
+        object? items = mutable.GetType().GetProperty("Items")!.GetValue(mutable);
+
+        items.ShouldBeOfType<List<int>>();
+        ((List<int>)items!).Add(3);
+
+        object rebuilt = Build(mutable);
+        var rebuiltItems = (IReadOnlyList<int>)bagType.GetProperty("Items")!.GetValue(rebuilt)!;
+        rebuiltItems.Count.ShouldBe(3);
+        rebuiltItems[2].ShouldBe(3);
+    }
+
+    [Test]
     public void DefaultImmutableArray_DoesNotThrowOnWrap()
     {
         // A record constructed with default(ImmutableArray<T>) must wrap without throwing

--- a/src/tests/Mutty.Tests/MutableRecordGeneratorTests.cs
+++ b/src/tests/Mutty.Tests/MutableRecordGeneratorTests.cs
@@ -203,6 +203,24 @@ public class MutableRecordGeneratorTests
                     /// Gets or sets the Age.
                     /// </summary>
                     public int Age { get; set; }
+
+                    /// <summary>
+                    /// Sets <see cref="Name"/> and returns this wrapper so calls can be chained.
+                    /// </summary>
+                    public MutableStudentDetails WithName(string value)
+                    {
+                        Name = value;
+                        return this;
+                    }
+
+                    /// <summary>
+                    /// Sets <see cref="Age"/> and returns this wrapper so calls can be chained.
+                    /// </summary>
+                    public MutableStudentDetails WithAge(int value)
+                    {
+                        Age = value;
+                        return this;
+                    }
                 }
             }
 

--- a/src/tests/Mutty.Tests/SnapshotTests.AllPrimitiveTypes.verified.txt
+++ b/src/tests/Mutty.Tests/SnapshotTests.AllPrimitiveTypes.verified.txt
@@ -165,5 +165,131 @@ namespace Mutty.Tests
         /// Gets or sets the StringValue.
         /// </summary>
         public string StringValue { get; set; }
+
+        /// <summary>
+        /// Sets <see cref="BoolValue"/> and returns this wrapper so calls can be chained.
+        /// </summary>
+        public MutableAllTypes WithBoolValue(bool value)
+        {
+            BoolValue = value;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets <see cref="ByteValue"/> and returns this wrapper so calls can be chained.
+        /// </summary>
+        public MutableAllTypes WithByteValue(byte value)
+        {
+            ByteValue = value;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets <see cref="SByteValue"/> and returns this wrapper so calls can be chained.
+        /// </summary>
+        public MutableAllTypes WithSByteValue(sbyte value)
+        {
+            SByteValue = value;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets <see cref="CharValue"/> and returns this wrapper so calls can be chained.
+        /// </summary>
+        public MutableAllTypes WithCharValue(char value)
+        {
+            CharValue = value;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets <see cref="ShortValue"/> and returns this wrapper so calls can be chained.
+        /// </summary>
+        public MutableAllTypes WithShortValue(short value)
+        {
+            ShortValue = value;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets <see cref="UShortValue"/> and returns this wrapper so calls can be chained.
+        /// </summary>
+        public MutableAllTypes WithUShortValue(ushort value)
+        {
+            UShortValue = value;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets <see cref="IntValue"/> and returns this wrapper so calls can be chained.
+        /// </summary>
+        public MutableAllTypes WithIntValue(int value)
+        {
+            IntValue = value;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets <see cref="UIntValue"/> and returns this wrapper so calls can be chained.
+        /// </summary>
+        public MutableAllTypes WithUIntValue(uint value)
+        {
+            UIntValue = value;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets <see cref="LongValue"/> and returns this wrapper so calls can be chained.
+        /// </summary>
+        public MutableAllTypes WithLongValue(long value)
+        {
+            LongValue = value;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets <see cref="ULongValue"/> and returns this wrapper so calls can be chained.
+        /// </summary>
+        public MutableAllTypes WithULongValue(ulong value)
+        {
+            ULongValue = value;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets <see cref="FloatValue"/> and returns this wrapper so calls can be chained.
+        /// </summary>
+        public MutableAllTypes WithFloatValue(float value)
+        {
+            FloatValue = value;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets <see cref="DoubleValue"/> and returns this wrapper so calls can be chained.
+        /// </summary>
+        public MutableAllTypes WithDoubleValue(double value)
+        {
+            DoubleValue = value;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets <see cref="DecimalValue"/> and returns this wrapper so calls can be chained.
+        /// </summary>
+        public MutableAllTypes WithDecimalValue(decimal value)
+        {
+            DecimalValue = value;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets <see cref="StringValue"/> and returns this wrapper so calls can be chained.
+        /// </summary>
+        public MutableAllTypes WithStringValue(string value)
+        {
+            StringValue = value;
+            return this;
+        }
     }
 }

--- a/src/tests/Mutty.Tests/SnapshotTests.BasicRecord.verified.txt
+++ b/src/tests/Mutty.Tests/SnapshotTests.BasicRecord.verified.txt
@@ -81,5 +81,23 @@ namespace Mutty.Tests
         /// Gets or sets the Age.
         /// </summary>
         public int Age { get; set; }
+
+        /// <summary>
+        /// Sets <see cref="Name"/> and returns this wrapper so calls can be chained.
+        /// </summary>
+        public MutablePerson WithName(string value)
+        {
+            Name = value;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets <see cref="Age"/> and returns this wrapper so calls can be chained.
+        /// </summary>
+        public MutablePerson WithAge(int value)
+        {
+            Age = value;
+            return this;
+        }
     }
 }

--- a/src/tests/Mutty.Tests/SnapshotTests.ComplexNestedGeneric.verified.txt
+++ b/src/tests/Mutty.Tests/SnapshotTests.ComplexNestedGeneric.verified.txt
@@ -81,5 +81,23 @@ namespace Mutty.Tests
         /// Gets or sets the ImmutableCollection NestedData.
         /// </summary>
         public List<Dictionary<string, int>> NestedData { get; set; }
+
+        /// <summary>
+        /// Sets <see cref="Name"/> and returns this wrapper so calls can be chained.
+        /// </summary>
+        public MutableComplexData WithName(string value)
+        {
+            Name = value;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets <see cref="NestedData"/> and returns this wrapper so calls can be chained.
+        /// </summary>
+        public MutableComplexData WithNestedData(List<Dictionary<string, int>> value)
+        {
+            NestedData = value;
+            return this;
+        }
     }
 }

--- a/src/tests/Mutty.Tests/SnapshotTests.MixedCollectionsWithBasicTypes.verified.txt
+++ b/src/tests/Mutty.Tests/SnapshotTests.MixedCollectionsWithBasicTypes.verified.txt
@@ -88,5 +88,32 @@ namespace Mutty.Tests
         /// Gets or sets the ImmutableCollection Mapping.
         /// </summary>
         public Dictionary<string, int> Mapping { get; set; }
+
+        /// <summary>
+        /// Sets <see cref="Numbers"/> and returns this wrapper so calls can be chained.
+        /// </summary>
+        public MutableMixedData WithNumbers(List<int> value)
+        {
+            Numbers = value;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets <see cref="Names"/> and returns this wrapper so calls can be chained.
+        /// </summary>
+        public MutableMixedData WithNames(List<string> value)
+        {
+            Names = value;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets <see cref="Mapping"/> and returns this wrapper so calls can be chained.
+        /// </summary>
+        public MutableMixedData WithMapping(Dictionary<string, int> value)
+        {
+            Mapping = value;
+            return this;
+        }
     }
 }

--- a/src/tests/Mutty.Tests/SnapshotTests.NestedRecord.verified.txt
+++ b/src/tests/Mutty.Tests/SnapshotTests.NestedRecord.verified.txt
@@ -83,6 +83,24 @@ namespace Mutty.Tests
         /// Gets or sets the City.
         /// </summary>
         public string City { get; set; }
+
+        /// <summary>
+        /// Sets <see cref="Street"/> and returns this wrapper so calls can be chained.
+        /// </summary>
+        public MutableAddress WithStreet(string value)
+        {
+            Street = value;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets <see cref="City"/> and returns this wrapper so calls can be chained.
+        /// </summary>
+        public MutableAddress WithCity(string value)
+        {
+            City = value;
+            return this;
+        }
     }
 }
 ,
@@ -170,6 +188,24 @@ namespace Mutty.Tests
         /// Gets or sets the Record HomeAddress.
         /// </summary>
         public global::Mutty.Tests.MutableAddress HomeAddress { get; set; }
+
+        /// <summary>
+        /// Sets <see cref="Name"/> and returns this wrapper so calls can be chained.
+        /// </summary>
+        public MutablePerson WithName(string value)
+        {
+            Name = value;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets <see cref="HomeAddress"/> and returns this wrapper so calls can be chained.
+        /// </summary>
+        public MutablePerson WithHomeAddress(global::Mutty.Tests.MutableAddress value)
+        {
+            HomeAddress = value;
+            return this;
+        }
     }
 }
 

--- a/src/tests/Mutty.Tests/SnapshotTests.NullableReferenceTypes.verified.txt
+++ b/src/tests/Mutty.Tests/SnapshotTests.NullableReferenceTypes.verified.txt
@@ -88,5 +88,32 @@ namespace Mutty.Tests
         /// Gets or sets the Email.
         /// </summary>
         public string? Email { get; set; }
+
+        /// <summary>
+        /// Sets <see cref="Name"/> and returns this wrapper so calls can be chained.
+        /// </summary>
+        public MutableUser WithName(string value)
+        {
+            Name = value;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets <see cref="MiddleName"/> and returns this wrapper so calls can be chained.
+        /// </summary>
+        public MutableUser WithMiddleName(string? value)
+        {
+            MiddleName = value;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets <see cref="Email"/> and returns this wrapper so calls can be chained.
+        /// </summary>
+        public MutableUser WithEmail(string? value)
+        {
+            Email = value;
+            return this;
+        }
     }
 }

--- a/src/tests/Mutty.Tests/SnapshotTests.NullableValueTypes.verified.txt
+++ b/src/tests/Mutty.Tests/SnapshotTests.NullableValueTypes.verified.txt
@@ -88,5 +88,32 @@ namespace Mutty.Tests
         /// Gets or sets the Rating.
         /// </summary>
         public double? Rating { get; set; }
+
+        /// <summary>
+        /// Sets <see cref="Score"/> and returns this wrapper so calls can be chained.
+        /// </summary>
+        public MutableStats WithScore(int value)
+        {
+            Score = value;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets <see cref="OptionalScore"/> and returns this wrapper so calls can be chained.
+        /// </summary>
+        public MutableStats WithOptionalScore(int? value)
+        {
+            OptionalScore = value;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets <see cref="Rating"/> and returns this wrapper so calls can be chained.
+        /// </summary>
+        public MutableStats WithRating(double? value)
+        {
+            Rating = value;
+            return this;
+        }
     }
 }

--- a/src/tests/Mutty.Tests/SnapshotTests.RecordWithImmutableDictionary.verified.txt
+++ b/src/tests/Mutty.Tests/SnapshotTests.RecordWithImmutableDictionary.verified.txt
@@ -81,5 +81,23 @@ namespace Mutty.Tests
         /// Gets or sets the ImmutableCollection Settings.
         /// </summary>
         public Dictionary<string, string> Settings { get; set; }
+
+        /// <summary>
+        /// Sets <see cref="Name"/> and returns this wrapper so calls can be chained.
+        /// </summary>
+        public MutableConfiguration WithName(string value)
+        {
+            Name = value;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets <see cref="Settings"/> and returns this wrapper so calls can be chained.
+        /// </summary>
+        public MutableConfiguration WithSettings(Dictionary<string, string> value)
+        {
+            Settings = value;
+            return this;
+        }
     }
 }

--- a/src/tests/Mutty.Tests/SnapshotTests.RecordWithImmutableList.verified.txt
+++ b/src/tests/Mutty.Tests/SnapshotTests.RecordWithImmutableList.verified.txt
@@ -81,5 +81,23 @@ namespace Mutty.Tests
         /// Gets or sets the ImmutableCollection Members.
         /// </summary>
         public List<string> Members { get; set; }
+
+        /// <summary>
+        /// Sets <see cref="Name"/> and returns this wrapper so calls can be chained.
+        /// </summary>
+        public MutableTeam WithName(string value)
+        {
+            Name = value;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets <see cref="Members"/> and returns this wrapper so calls can be chained.
+        /// </summary>
+        public MutableTeam WithMembers(List<string> value)
+        {
+            Members = value;
+            return this;
+        }
     }
 }

--- a/src/tests/Mutty.Tests/SnapshotTests.RecordWithMultipleCollections.verified.txt
+++ b/src/tests/Mutty.Tests/SnapshotTests.RecordWithMultipleCollections.verified.txt
@@ -88,5 +88,32 @@ namespace Mutty.Tests
         /// Gets or sets the ImmutableCollection Metrics.
         /// </summary>
         public Dictionary<string, double> Metrics { get; set; }
+
+        /// <summary>
+        /// Sets <see cref="Name"/> and returns this wrapper so calls can be chained.
+        /// </summary>
+        public MutableDataSet WithName(string value)
+        {
+            Name = value;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets <see cref="Numbers"/> and returns this wrapper so calls can be chained.
+        /// </summary>
+        public MutableDataSet WithNumbers(List<int> value)
+        {
+            Numbers = value;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets <see cref="Metrics"/> and returns this wrapper so calls can be chained.
+        /// </summary>
+        public MutableDataSet WithMetrics(Dictionary<string, double> value)
+        {
+            Metrics = value;
+            return this;
+        }
     }
 }


### PR DESCRIPTION
Continues the v2.0.0 work. Follow-up to #153/#154/#155.

## P20 — array & read-only-collection members no longer aliased
A plain `T[]` or `IReadOnlyList<T>` / `IReadOnlyCollection<T>` property fell through to `PropertyType.Other` and was assigned **by reference**, so mutating the wrapper corrupted the source record (and vice-versa).
- **Arrays** keep their `T[]` type but are defensively copied (`ToArray()`) on both ingest and `Build()`, so element mutations stay isolated.
- **Read-only collections** are exposed as a mutable `List<T>` (`ToList()` in and out).
- Nullable members handled with null-conditional copies.
- E2E tests assert isolation (source not corrupted; `Build()` yields a fresh copy) and that read-only lists become mutable `List<T>`.

## P28 — fluent `With{Property}` setters
Each wrapper now exposes chainable setters returning the wrapper:
```csharp
var updated = student.Produce(m => m.WithName("Jane").WithAge(30));
```
The parameter uses the property's mutable type (nested `Mutable{X}`, `List<T>` for collections, etc.) via a shared `GetMutablePropertyType` helper. E2E test covers chaining through `Produce`.

README + CHANGELOG updated; snapshots and the exact-output test re-accepted.

**127 tests passing, 0 skipped.**

## Remaining v2 candidates
- **P25** — edge-case tests (required / init-only / positional records, file-scoped vs block namespaces).
- **P16** — FQN+arity hint names (low priority).

🤖 Generated with [Claude Code](https://claude.com/claude-code)